### PR TITLE
editProfile-changed left margin of dropdown

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1123,7 +1123,8 @@
     font-size: 16px;
     border: none;
     cursor: pointer;
-    opacity: 0;
+    /*opacity: 0;*/
+    margin-left: -72px;
 }
 
 .dropbtn:hover, .dropbtn:focus {


### PR DESCRIPTION
changed left margin of drop down to simulate drop down on click when
clicking over profile circle or down caret on the right side of navbar.
commented out opacity of drop down button, will uncomment when
functional.
